### PR TITLE
Feature/read operation test

### DIFF
--- a/common/lru/basiclru.go
+++ b/common/lru/basiclru.go
@@ -75,12 +75,14 @@ func (c *BasicLRU[K, V]) Add(key K, value V) (evicted bool) {
 
 // Contains reports whether the given key exists in the cache.
 func (c *BasicLRU[K, V]) Contains(key K) bool {
+	return false
 	_, ok := c.items[key]
 	return ok
 }
 
 // Get retrieves a value from the cache. This marks the key as recently used.
 func (c *BasicLRU[K, V]) Get(key K) (value V, ok bool) {
+	return value, false
 	item, ok := c.items[key]
 	if !ok {
 		return value, false
@@ -92,6 +94,7 @@ func (c *BasicLRU[K, V]) Get(key K) (value V, ok bool) {
 // GetOldest retrieves the least-recently-used item.
 // Note that this does not update the item's recency.
 func (c *BasicLRU[K, V]) GetOldest() (key K, value V, ok bool) {
+	return key, value, false
 	lastElem := c.list.last()
 	if lastElem == nil {
 		return key, value, false

--- a/common/lru/lru.go
+++ b/common/lru/lru.go
@@ -16,7 +16,9 @@
 
 package lru
 
-import "sync"
+import (
+	"sync"
+)
 
 // Cache is a LRU cache.
 // This type is safe for concurrent use.
@@ -40,6 +42,7 @@ func (c *Cache[K, V]) Add(key K, value V) (evicted bool) {
 
 // Contains reports whether the given key exists in the cache.
 func (c *Cache[K, V]) Contains(key K) bool {
+	return false
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -48,6 +51,7 @@ func (c *Cache[K, V]) Contains(key K) bool {
 
 // Get retrieves a value from the cache. This marks the key as recently used.
 func (c *Cache[K, V]) Get(key K) (value V, ok bool) {
+	return value, false
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -22,6 +22,7 @@ package leveldb
 
 import (
 	"fmt"
+	"github.com/ethereum/go-ethereum/hook"
 	"strings"
 	"sync"
 	"time"
@@ -185,11 +186,13 @@ func (db *Database) Close() error {
 
 // Has retrieves if a key is present in the key-value store.
 func (db *Database) Has(key []byte) (bool, error) {
+	hook.Gr.CountLevelDbRead(key)
 	return db.db.Has(key, nil)
 }
 
 // Get retrieves the given key if it's present in the key-value store.
 func (db *Database) Get(key []byte) ([]byte, error) {
+	hook.Gr.CountLevelDbRead(key)
 	dat, err := db.db.Get(key, nil)
 	if err != nil {
 		return nil, err
@@ -469,12 +472,14 @@ type snapshot struct {
 // Has retrieves if a key is present in the snapshot backing by a key-value
 // data store.
 func (snap *snapshot) Has(key []byte) (bool, error) {
+	hook.Gr.CountLevelDbSnapshotRead(key)
 	return snap.db.Has(key, nil)
 }
 
 // Get retrieves the given key if it's present in the snapshot backing by
 // key-value data store.
 func (snap *snapshot) Get(key []byte) ([]byte, error) {
+	hook.Gr.CountLevelDbSnapshotRead(key)
 	return snap.db.Get(key, nil)
 }
 

--- a/ethdb/pebble/pebble.go
+++ b/ethdb/pebble/pebble.go
@@ -19,6 +19,7 @@ package pebble
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"runtime"
 	"sync"
@@ -136,6 +137,7 @@ func (l panicLogger) Fatalf(format string, args ...interface{}) {
 // New returns a wrapped pebble DB object. The namespace is the prefix that the
 // metrics reporting should use for surfacing internal stats.
 func New(file string, cache int, handles int, namespace string, readonly bool, ephemeral bool) (*Database, error) {
+	return nil, errors.New("this repo doesn't support pebble DB")
 	// Ensure we have some minimal caching and file guarantees
 	if cache < minCache {
 		cache = minCache

--- a/hook/record.go
+++ b/hook/record.go
@@ -1,0 +1,132 @@
+package hook
+
+import "sync"
+
+type Record struct {
+	ancientDbReadCnt          int // ancient DB 접근 횟수
+	levelDbReadCnt            int // level DB 접근 횟수
+	levelDbSnapshotReadCnt    int // level DB 스냅샷 접근 횟수
+	duplicatedReadCnt         int // 중복 디비 접근 횟수
+	duplicatedSnapshotReadCnt int // 중복 스냅샷 접근 횟수
+	readDbKeySet              *map[string]bool
+	readDbKeySetLock          sync.RWMutex
+	readSnapshotDbKeySet      *map[string]bool
+	readSnapshotDbKeySetLock  sync.RWMutex
+	rpcLock                   sync.Mutex
+}
+
+var Gr = Record{
+	ancientDbReadCnt:          0,
+	levelDbReadCnt:            0,
+	levelDbSnapshotReadCnt:    0,
+	duplicatedReadCnt:         0,
+	duplicatedSnapshotReadCnt: 0,
+	readDbKeySet:              &map[string]bool{},
+	readDbKeySetLock:          sync.RWMutex{},
+	readSnapshotDbKeySet:      &map[string]bool{},
+	readSnapshotDbKeySetLock:  sync.RWMutex{},
+	rpcLock:                   sync.Mutex{},
+}
+
+func (gr *Record) Lock() {
+	gr.rpcLock.Lock()
+}
+
+func (gr *Record) Unlock() {
+	gr.rpcLock.Unlock()
+}
+
+func (gr *Record) Reset() {
+	gr.ancientDbReadCnt = 0
+	gr.levelDbReadCnt = 0
+	gr.levelDbSnapshotReadCnt = 0
+	gr.duplicatedReadCnt = 0
+	gr.duplicatedSnapshotReadCnt = 0
+	gr.readDbKeySet = &map[string]bool{}
+	gr.readSnapshotDbKeySet = &map[string]bool{}
+}
+
+func (gr *Record) addReadKeySet(key string) {
+	gr.readDbKeySetLock.Lock()
+	defer gr.readDbKeySetLock.Unlock()
+
+	(*gr.readDbKeySet)[key] = true
+}
+
+func (gr *Record) addReadSnapshotKeySet(key string) {
+	gr.readSnapshotDbKeySetLock.Lock()
+	defer gr.readSnapshotDbKeySetLock.Unlock()
+
+	(*gr.readSnapshotDbKeySet)[key] = true
+}
+
+func (gr *Record) isAlreadyRead(key string) bool {
+	gr.readDbKeySetLock.RLock()
+	defer gr.readDbKeySetLock.RUnlock()
+	if (*gr.readDbKeySet)[key] == true {
+		return true
+	}
+	return false
+}
+
+func (gr *Record) countDuplicatedKey(key []byte) {
+	keyStr := string(key[:])
+	if gr.isAlreadyRead(keyStr) {
+		gr.duplicatedReadCnt++
+	} else {
+		gr.addReadKeySet(keyStr)
+	}
+}
+
+func (gr *Record) isAlreadyReadSnapshot(key string) bool {
+	gr.readSnapshotDbKeySetLock.RLock()
+	defer gr.readSnapshotDbKeySetLock.RUnlock()
+	if (*gr.readSnapshotDbKeySet)[key] == true {
+		return true
+	}
+	return false
+}
+
+func (gr *Record) countDuplicatedSnapshotKey(key []byte) {
+	keyStr := string(key[:])
+	if gr.isAlreadyReadSnapshot(keyStr) {
+		gr.duplicatedSnapshotReadCnt++
+	} else {
+		gr.addReadSnapshotKeySet(keyStr)
+	}
+}
+
+func (gr *Record) CountAncientDbRead(key []byte) {
+	gr.countDuplicatedKey(key)
+	gr.ancientDbReadCnt++
+}
+
+func (gr *Record) CountLevelDbRead(key []byte) {
+	gr.countDuplicatedKey(key)
+	gr.levelDbReadCnt++
+}
+
+func (gr *Record) CountLevelDbSnapshotRead(key []byte) {
+	gr.countDuplicatedSnapshotKey(key)
+	gr.levelDbSnapshotReadCnt++
+}
+
+func (gr *Record) AncientDbReadCnt() int {
+	return gr.ancientDbReadCnt
+}
+
+func (gr *Record) LevelDbReadCnt() int {
+	return gr.levelDbReadCnt
+}
+
+func (gr *Record) LevelDbSnapshotReadCnt() int {
+	return gr.levelDbSnapshotReadCnt
+}
+
+func (gr *Record) DuplicatedReadCnt() int {
+	return gr.duplicatedReadCnt
+}
+
+func (gr *Record) DuplicatedSnapshotReadCnt() int {
+	return gr.duplicatedSnapshotReadCnt
+}


### PR DESCRIPTION
- basic LRU & LRU 캐쉬 기능 off
- DB 읽기 횟수 측정을 위한 record 모듈 추가
  - leveldb read 횟수 카운팅
  - leveldb snapshot read 횟수 카운팅
  - ancientdb read 횟수 카운팅
  - 중복으로 읽은 키에 대해서 카운팅
- handler.go 파일에서 RPC 시작 & RPC 끝나는 부분에 record 관련 로직을 추가하고, RPC 호출이 끝날때 DB 접근 횟수 통계 출력
- DB에 접근하는 파일들에서 record 모듈을 호출하여 카운팅하도록 로직 추가